### PR TITLE
Fixed Record Handler and added Test.

### DIFF
--- a/api/src/main/java/org/pragmaticminds/crunch/api/pipe/RecordHandler.java
+++ b/api/src/main/java/org/pragmaticminds/crunch/api/pipe/RecordHandler.java
@@ -55,6 +55,9 @@ public interface RecordHandler extends Serializable {
     /**
      * Collects all channel identifiers that are used in the record handler
      * @return a {@link List} or {@link Collection} of all channel identifiers
+     *
+     * @deprecated should be ignored?!
      */
+    @Deprecated
     Set<String> getChannelIdentifiers();
 }

--- a/api/src/main/java/org/pragmaticminds/crunch/execution/NoOpSink.java
+++ b/api/src/main/java/org/pragmaticminds/crunch/execution/NoOpSink.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.pragmaticminds.crunch.execution;
+
+import java.io.Serializable;
+
+/**
+ * Sink that does Nothing.
+ */
+public class NoOpSink implements EventSink<Serializable> {
+
+  public static final NoOpSink INSTANCE = new NoOpSink();
+
+  private NoOpSink() {
+  }
+
+  @Override public void handle(Serializable event) {
+  }
+
+}


### PR DESCRIPTION
Fixes the problem with the record handlers only getting filtered channels or no messags at all.
Now, Record handlers are called after the predicate of the substream and get ALL messages to process.
An example for the usage (also without Evaluation Functions in the Substream) can be found in

CrunchExecutorTest.resultHandlerSendsBeforeFilter()